### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/docs/user/default-placeholders.md
+++ b/docs/user/default-placeholders.md
@@ -12,9 +12,9 @@ Prior to 1.19, arguments were separated with a slash (`/`) instead of space.
 
 !!! tip inline end "Vanilla Statistics"
 
-    A list of `[statistic]`s can be found on the [Minecraft Wiki](https://minecraft.fandom.com/wiki/Statistics#List_of_custom_statistic_names)
+    A list of `[statistic]`s can be found on the [Minecraft Wiki](https://minecraft.wiki/w/Statistics#List_of_custom_statistic_names)
 
-    A list of `[type]`s can be found on the [Minecraft Wiki](https://minecraft.fandom.com/wiki/Statistics#Statistic_types_and_names)
+    A list of `[type]`s can be found on the [Minecraft Wiki](https://minecraft.wiki/w/Statistics#Statistic_types_and_names)
 
     Examples: `%player:statistic play_time%`, `%player:statistic mined diamond_ore%`
 

--- a/docs/user/text-format.md
+++ b/docs/user/text-format.md
@@ -145,7 +145,7 @@ and `[optional arg X]` are optional, fully formatted arguments you can pass.
 
 !!! question inline end "Control Keys"
 
-    You can find a list of control keys on the [Minecraft Wiki](https://minecraft.fandom.com/wiki/Controls#Configurable_controls)
+    You can find a list of control keys on the [Minecraft Wiki](https://minecraft.wiki/w/Controls#Configurable_controls)
 
 !!! note inline end
 


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: <https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom>. This PR updates all the URLs to the new domain: minecraft.wiki