### PR TITLE
Bug and crash fixing

### DIFF
--- a/src/main/java/eu/pb4/placeholders/impl/placeholder/builtin/PlayerPlaceholders.java
+++ b/src/main/java/eu/pb4/placeholders/impl/placeholder/builtin/PlayerPlaceholders.java
@@ -370,7 +370,7 @@ public class PlayerPlaceholders {
 
         Placeholders.register(new Identifier("player", "hunger"), (ctx, arg) -> {
             if (ctx.hasPlayer()) {
-                return PlaceholderResult.value(String.format("%.0f", ctx.player().getHungerManager().getFoodLevel()));
+                return PlaceholderResult.value(String.valueOf(ctx.player().getHungerManager().getFoodLevel()));
             } else {
                 return PlaceholderResult.invalid("No player!");
             }

--- a/src/main/java/eu/pb4/placeholders/impl/textparser/TextTags.java
+++ b/src/main/java/eu/pb4/placeholders/impl/textparser/TextTags.java
@@ -478,6 +478,11 @@ public final class TextTags {
                                         textColors.add(color);
                                     }
                                 }
+                                // We cannot have an empty list!
+                                if (textColors.isEmpty()) {
+                                    return out.value(new ParentNode(out.nodes()));
+                                }
+
                                 return out.value(GradientNode.colorsHard(textColors, out.nodes()));
 
                             }


### PR DESCRIPTION
- Fixes a bug that caused the game to crash when a player uses the gradient with no parameters.
```
java.lang.IndexOutOfBoundsException: Index -1 out of bounds for length 0
	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70)
	at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:266)
	at java.base/java.util.Objects.checkIndex(Objects.java:359)
	at java.base/java.util.ArrayList.get(ArrayList.java:427)
	at eu.pb4.placeholders.api.node.parent.GradientNode$GradientProvider.lambda$colorsHard$1(GradientNode.java:145)
	at eu.pb4.placeholders.impl.GeneralUtils.recursiveGradient(GeneralUtils.java:97)
	at eu.pb4.placeholders.impl.GeneralUtils.toGradient(GeneralUtils.java:65)
	at eu.pb4.placeholders.api.node.parent.GradientNode.applyFormatting(GradientNode.java:69)
	at eu.pb4.placeholders.api.node.parent.ParentNode.toText(ParentNode.java:73)
	at eu.pb4.placeholders.api.node.TextNode.toText(TextNode.java:24)
	at eu.pb4.placeholders.api.parsers.StaticPreParser.parse(StaticPreParser.java:23)
	at eu.pb4.placeholders.api.parsers.StaticPreParser.parseNodes(StaticPreParser.java:18)
	at eu.pb4.placeholders.impl.textparser.MergedParser.parseNodes(MergedParser.java:17)
	at eu.pb4.placeholders.api.parsers.NodeParser.parseNode(NodeParser.java:17)
	at eu.pb4.placeholders.api.parsers.NodeParser.parseNode(NodeParser.java:21)
```
- Fixed "%player:hunger%" from not working and erroring.
  - Hunger was previously trying to be formatted as a float when it's an integer causing:
  ```
  java.util.IllegalFormatConversionException: f != java.lang.Integer
	at java.util.Formatter$FormatSpecifier.failConversion(Formatter.java:4442) ~[?:?]
	at java.util.Formatter$FormatSpecifier.printFloat(Formatter.java:2976) ~[?:?]
	at java.util.Formatter$FormatSpecifier.print(Formatter.java:2924) ~[?:?]
	at java.util.Formatter.format(Formatter.java:2689) ~[?:?]
	at java.util.Formatter.format(Formatter.java:2625) ~[?:?]
	at java.lang.String.format(String.java:4141) ~[?:?]
	at eu.pb4.placeholders.impl.placeholder.builtin.PlayerPlaceholders.lambda$register$22(PlayerPlaceholders.java:373) ~[placeholder-api-2.2.0+1.20.2.jar:?]
	at eu.pb4.placeholders.impl.placeholder.PlaceholderNode.toText(PlaceholderNode.java:21) ~[placeholder-api-2.2.0+1.20.2.jar:?]
	at eu.pb4.placeholders.api.node.parent.ParentNode.toText(ParentNode.java:52) ~[placeholder-api-2.2.0+1.20.2.jar:?]
	at eu.pb4.placeholders.api.node.TextNode.toText(TextNode.java:16) ~[placeholder-api-2.2.0+1.20.2.jar:?]
  ```