### PR TITLE
Object[] CASTER fix, loader bump

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,10 +5,10 @@ org.gradle.jvmargs=-Xmx1G
 	# check these on https://fabricmc.net/use
 	minecraft_version=1.20.3-rc1
 	yarn_mappings=1.20.3-rc1+build.1
-	loader_version=0.14.24
+	loader_version=0.15.0
 
 	#Fabric api
-	fabric_version=0.90.9+1.20.3
+	fabric_version=0.91.1+1.20.3
 
 	# Mod Properties
 	mod_version = 2.3.0+1.20.3

--- a/src/main/java/eu/pb4/placeholders/impl/textparser/TextTags.java
+++ b/src/main/java/eu/pb4/placeholders/impl/textparser/TextTags.java
@@ -141,7 +141,7 @@ public final class TextTags {
                                 textList.add(new ParentNode(parse(removeEscaping(cleanArgument(part)), handlers)));
                             }
 
-                            var out = TranslatedNode.of(removeEscaping(cleanArgument(lines[0])), textList.toArray(TextParserImpl.CASTER));
+                            var out = TranslatedNode.of(removeEscaping(cleanArgument(lines[0])), textList.toArray((Object[]) TextParserImpl.CASTER));
                             return new TextParserV1.TagNodeValue(out, 0);
                         }
                         return TextParserV1.TagNodeValue.EMPTY;
@@ -167,7 +167,7 @@ public final class TextTags {
                                 textList.add(new ParentNode(parse(removeEscaping(cleanArgument(part)), handlers)));
                             }
 
-                            var out = TranslatedNode.ofFallback(removeEscaping(cleanArgument(lines[0])), removeEscaping(cleanArgument(lines[1])), textList.toArray(TextParserImpl.CASTER));
+                            var out = TranslatedNode.ofFallback(removeEscaping(cleanArgument(lines[0])), removeEscaping(cleanArgument(lines[1])), textList.toArray((Object[]) TextParserImpl.CASTER));
                             return new TextParserV1.TagNodeValue(out, 0);
                         }
                         return TextParserV1.TagNodeValue.EMPTY;


### PR DESCRIPTION
this fixed my test environment, without it, it caused a minecraft crash with the official 2.3.0 build that I downloaded from your release build when my mod tried to register placeholders ...  They will also probably do 0.15.0 for the loader once 1.20.3 official comes out...  Up to you.

Test it if you like with my afkplus 1.20.3 build.