### PR TITLE
Fix objective_name_top & objective_score_top not sorted correctly (issue #75)

### DIFF
--- a/src/main/java/eu/pb4/placeholders/impl/placeholder/builtin/ServerPlaceholders.java
+++ b/src/main/java/eu/pb4/placeholders/impl/placeholder/builtin/ServerPlaceholders.java
@@ -22,9 +22,7 @@ import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.util.Collection;
-import java.util.Date;
-import java.util.Objects;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 public class ServerPlaceholders {
@@ -185,8 +183,10 @@ public class ServerPlaceholders {
                 }
                 try {
                     int position = Integer.parseInt(args[1]);
-                    Collection<ScoreboardEntry> scoreboardEntries = scoreboard.getScoreboardEntries(scoreboardObjective);
-                    ScoreboardEntry scoreboardEntry = scoreboardEntries.toArray(ScoreboardEntry[]::new)[scoreboardEntries.size() - position];
+                    List<ScoreboardEntry> scoreboardEntries = new ArrayList<>(scoreboard.getScoreboardEntries(scoreboardObjective));
+                    scoreboardEntries.sort(Comparator.comparingInt(ScoreboardEntry::value).reversed());
+
+                    ScoreboardEntry scoreboardEntry = scoreboardEntries.get(position - 1);
                     return PlaceholderResult.value(scoreboardEntry.name());
                 } catch (Exception e) {
                     /* Into the void you go! */
@@ -205,8 +205,10 @@ public class ServerPlaceholders {
                 }
                 try {
                     int position = Integer.parseInt(args[1]);
-                    Collection<ScoreboardEntry> scoreboardEntries = scoreboard.getScoreboardEntries(scoreboardObjective);
-                    ScoreboardEntry scoreboardEntry = scoreboardEntries.toArray(ScoreboardEntry[]::new)[scoreboardEntries.size() - position];
+                    List<ScoreboardEntry> scoreboardEntries = new ArrayList<>(scoreboard.getScoreboardEntries(scoreboardObjective));
+                    scoreboardEntries.sort(Comparator.comparingInt(ScoreboardEntry::value).reversed());
+
+                    ScoreboardEntry scoreboardEntry = scoreboardEntries.get(position - 1);
                     return PlaceholderResult.value(String.valueOf(scoreboardEntry.value()));
                 } catch (Exception e) {
                     /* Into the void you go! */


### PR DESCRIPTION
objective_name_top & objective_score_top placeholders are now sorted correctly

My guess is that ``ServerScoreboard#getScoreboardEntries`` uses a Map which is not ordered by the score value.

So in here:
https://github.com/Patbox/TextPlaceholderAPI/blob/8a6dce7a87685ac77a1b55cbd2533787366ae355/src/main/java/eu/pb4/placeholders/impl/placeholder/builtin/ServerPlaceholders.java#L208

We have to sort it manually after getting the score values. So I used a List instead of a Collection to use the ``List#sort()`` method.

It's working, I have tested in-game :)

![2025-04-28_21 24 22](https://github.com/user-attachments/assets/96af3030-4831-4498-9fb9-de1276acf0a7)
