### PR TITLE
Feat: A server placeholder for pulling the score from a specific player

### DIFF
--- a/docs/user/default-placeholders.md
+++ b/docs/user/default-placeholders.md
@@ -85,6 +85,7 @@ Prior to 1.19, arguments were separated with a slash (`/`) instead of space.
 - `%server:mod_description [modid]%` - Returns description of the specified mod.
 - `%server:objective_name_top [objective] [position]%` - Shows name of the player at the `position`th place in the scoreboard `objective`.
 - `%server:objective_score_top [objective] [position]%` - Shows score of the player at the `position`th place in the scoreboard `objective`.
+- `%server:objective_score_player [objective] [player]%` - Shows score of the specified `player` in the scoreboard `objective`.
 
 *[TPS]: Ticks Per Second. The number of ticks per second executing on the server. <20 TPS means the server is lagging.
 *[MSPT]: Milliseconds Per Tick. The number of milliseconds it takes for a tick on the server. >50 MSPT means the server is lagging.

--- a/src/main/java/eu/pb4/placeholders/impl/placeholder/builtin/ServerPlaceholders.java
+++ b/src/main/java/eu/pb4/placeholders/impl/placeholder/builtin/ServerPlaceholders.java
@@ -217,5 +217,25 @@ public class ServerPlaceholders {
             }
             return PlaceholderResult.invalid("Not enough arguments!");
         });
+
+        Placeholders.register(Identifier.of("server", "objective_score_player"), (ctx, arg) -> {
+            var args = arg.split(" ");
+            if (args.length >= 2) {
+                ServerScoreboard scoreboard = ctx.server().getScoreboard();
+                ScoreboardObjective scoreboardObjective = scoreboard.getNullableObjective(args[0]);
+                if (scoreboardObjective == null) {
+                    return PlaceholderResult.invalid("Invalid Objective!");
+                }
+                try {
+                    Collection<ScoreboardEntry> scoreboardEntries = scoreboard.getScoreboardEntries(scoreboardObjective);
+                    ScoreboardEntry entry = scoreboardEntries.stream().filter(scoreboardEntry -> scoreboardEntry.name().getString().equals(args[1])).toList().getFirst();
+
+                    return PlaceholderResult.value(String.valueOf(entry.value()));
+                } catch (Exception e) {
+                    return PlaceholderResult.invalid("Player Not Found!");
+                }
+            }
+            return PlaceholderResult.invalid("Not enough arguments!");
+        });
     }
 }


### PR DESCRIPTION
I didn't see a way to pull the score for specific player rather than the current user, this adds a placeholder to specify the objective and which player name to grab the value from. 

Useful for datapacking where saving global information may be done in one large scoreboard using custom player names. 