### PR TITLE
Fix parsing during server start

### DIFF
--- a/src/main/java/eu/pb4/placeholders/api/node/parent/ClickActionNode.java
+++ b/src/main/java/eu/pb4/placeholders/api/node/parent/ClickActionNode.java
@@ -15,9 +15,7 @@ import net.minecraft.nbt.NbtOps;
 import net.minecraft.nbt.SnbtOperation;
 import net.minecraft.nbt.SnbtParsing;
 import net.minecraft.nbt.StringNbtReader;
-import net.minecraft.registry.RegistryKey;
-import net.minecraft.registry.RegistryKeys;
-import net.minecraft.registry.RegistryWrapper;
+import net.minecraft.registry.*;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.text.ClickEvent;
 import net.minecraft.text.Style;
@@ -31,6 +29,8 @@ public final class ClickActionNode extends SimpleStylingNode {
     private final ClickEvent.Action action;
     private final TextNode value;
     private final @Nullable Either<TextNode, StringArgs> data;
+
+    private static final RegistryWrapper.WrapperLookup DEFAULT_WRAPPER = DynamicRegistryManager.of(Registries.REGISTRIES);
 
     public ClickActionNode(TextNode[] children, ClickEvent.Action action, TextNode value) {
         this(children, action, value, null);
@@ -79,7 +79,7 @@ public final class ClickActionNode extends SimpleStylingNode {
                     } else if (context.contains(PlaceholderContext.KEY)) {
                         wrapper = context.getOrThrow(PlaceholderContext.KEY).server().getRegistryManager();
                     } else {
-                        wrapper = GeneralUtils.DEFAULT_WRAPPER;
+                        wrapper = DEFAULT_WRAPPER;
                     }
 
                     yield Style.EMPTY.withClickEvent(new ClickEvent.Custom(
@@ -101,7 +101,7 @@ public final class ClickActionNode extends SimpleStylingNode {
                 } else if (context.contains(PlaceholderContext.KEY)) {
                     wrapper = context.getOrThrow(PlaceholderContext.KEY).server().getRegistryManager();
                 } else {
-                    wrapper = GeneralUtils.DEFAULT_WRAPPER;
+                    wrapper = DEFAULT_WRAPPER;
                 }
                 RegistryEntry<Dialog> dialogRegistryEntry = null;
                 var data = this.value.toText(context).getString();

--- a/src/main/java/eu/pb4/placeholders/impl/GeneralUtils.java
+++ b/src/main/java/eu/pb4/placeholders/impl/GeneralUtils.java
@@ -5,9 +5,6 @@ import eu.pb4.placeholders.api.node.parent.*;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.component.DataComponentTypes;
 import net.minecraft.item.ItemStack;
-import net.minecraft.registry.DynamicRegistryManager;
-import net.minecraft.registry.Registries;
-import net.minecraft.registry.RegistryWrapper;
 import net.minecraft.text.*;
 import net.minecraft.util.Formatting;
 import org.jetbrains.annotations.ApiStatus;
@@ -26,7 +23,6 @@ public class GeneralUtils {
     public static final Logger LOGGER = LoggerFactory.getLogger("Text Placeholder API");
     public static final boolean IS_DEV = FabricLoader.getInstance().isDevelopmentEnvironment();
     public static final TextNode[] CASTER = new TextNode[0];
-    public static final RegistryWrapper.WrapperLookup DEFAULT_WRAPPER = DynamicRegistryManager.of(Registries.REGISTRIES);
 
     public static String durationToString(long x) {
         long seconds = x % 60;


### PR DESCRIPTION
This PR fixes an error that would occur when parsing nodes early during the server start, more specifcally when (some?) registries are not loaded yet.

I wrote [a mod that replaces translation strings](https://github.com/arvitus/ServerMessages) (by mixing into `net.minecraft.text.MutableText.of()`) and when I tried to replace some constant strings in `net.minecraft.command.TranslatableBuiltInExceptions` I got this error: `java.lang.IllegalArgumentException: Not bootstrapped (called from registry minecraft:game_event)`
I believe this was caused because during node parsing [a method in the GeneralUtils class](https://github.com/Patbox/TextPlaceholderAPI/blob/1.21.6/src/main/java/eu/pb4/placeholders/impl/GeneralUtils.java#L50) is called, which initializes [a static field that accesses the registry](https://github.com/Patbox/TextPlaceholderAPI/blob/1.21.6/src/main/java/eu/pb4/placeholders/impl/GeneralUtils.java#L29). Since the registry seems to not be loaded yet, it throws the error. By moving this static field out of the `GeneralUtils`, this can be prevented.

I tested my changes, and the error did not occur anymore.

This is the error I got:
```
[23:25:12] [main/INFO]: Initializing MixinExtras via com.llamalad7.mixinextras.service.MixinExtrasServiceImpl(version=0.5.0-rc.2).
[23:25:13] [main/ERROR]: Minecraft has crashed!
net.fabricmc.loader.impl.FormattedException: java.lang.ExceptionInInitializerError
        at net.fabricmc.loader.impl.FormattedException.ofLocalized(FormattedException.java:63) ~[fabric-loader-0.16.14.jar:?]
        at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:482) ~[fabric-loader-0.16.14.jar:?]
        at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:74) [fabric-loader-0.16.14.jar:?]
        at net.fabricmc.loader.impl.launch.knot.KnotServer.main(KnotServer.java:23) [fabric-loader-0.16.14.jar:?]
        at net.fabricmc.loader.impl.launch.server.FabricServerLauncher.main(FabricServerLauncher.java:69) [fabric-loader-0.16.14.jar:?]
        at net.fabricmc.installer.ServerLauncher.main(ServerLauncher.java:69) [fabric-server-mc.1.21.6-loader.0.16.14-launcher.1.0.3.jar:1.0.3]
Caused by: java.lang.ExceptionInInitializerError
        at knot/eu.pb4.placeholders.impl.GeneralUtils.<clinit>(GeneralUtils.java:28) ~[placeholder-api-2.7.0+1.21.6-23b132bdbfc53dbe.jar:?]
        at knot/eu.pb4.placeholders.api.node.parent.ParentNode.toText(ParentNode.java:61) ~[placeholder-api-2.7.0+1.21.6-23b132bdbfc53dbe.jar:?]
        at knot/eu.pb4.placeholders.api.node.TextNode.toText(TextNode.java:23) ~[placeholder-api-2.7.0+1.21.6-23b132bdbfc53dbe.jar:?]
        at knot/eu.pb4.placeholders.api.parsers.StaticPreParser.parse(StaticPreParser.java:23) ~[placeholder-api-2.7.0+1.21.6-23b132bdbfc53dbe.jar:?]
        at knot/eu.pb4.placeholders.api.parsers.StaticPreParser.parseNodes(StaticPreParser.java:18) ~[placeholder-api-2.7.0+1.21.6-23b132bdbfc53dbe.jar:?]
        at knot/eu.pb4.placeholders.impl.textparser.MergedParser.parseNodes(MergedParser.java:50) ~[placeholder-api-2.7.0+1.21.6-23b132bdbfc53dbe.jar:?]
        at knot/de.example.servermessages.WrappedLangText.from(WrappedLangText.java:14) ~[servermessages-1.0.0-1.21.2.jar:?]
        at knot/de.example.servermessages.Config.<clinit>(Config.java:40) ~[servermessages-1.0.0-1.21.2.jar:?]
        at knot/net.minecraft.class_5250.handler$beh000$servermessages$replaceCustomTranslations(class_5250.java:534) ~[server-intermediary.jar:?]
        at knot/net.minecraft.class_5250.method_43477(class_5250.java) ~[server-intermediary.jar:?]
        at knot/net.minecraft.class_2561.method_43471(class_2561.java:152) ~[server-intermediary.jar:?]
        at knot/net.minecraft.class_2156.<clinit>(class_2156.java:24) ~[server-intermediary.jar:?]
        at knot/net.minecraft.class_155.<clinit>(class_155.java:244) ~[server-intermediary.jar:?]
        at knot/net.minecraft.server.Main.main(Main.java:71) ~[server-intermediary.jar:?]
        at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:480) ~[fabric-loader-0.16.14.jar:?]
        ... 4 more
Caused by: java.lang.IllegalArgumentException: Not bootstrapped (called from registry minecraft:game_event)
        at knot/net.minecraft.class_2966.method_36237(class_2966.java:122) ~[server-intermediary.jar:?]
        at knot/net.minecraft.class_2966.method_36235(class_2966.java:115) ~[server-intermediary.jar:?]
        at knot/net.minecraft.class_7923.method_47478(class_7923.java:267) ~[server-intermediary.jar:?]
        at knot/net.minecraft.class_7923.method_47481(class_7923.java:258) ~[server-intermediary.jar:?]
        at knot/net.minecraft.class_7923.<clinit>(class_7923.java:157) ~[server-intermediary.jar:?]
        at knot/eu.pb4.placeholders.impl.GeneralUtils.<clinit>(GeneralUtils.java:28) ~[placeholder-api-2.7.0+1.21.6-23b132bdbfc53dbe.jar:?]
        at knot/eu.pb4.placeholders.api.node.parent.ParentNode.toText(ParentNode.java:61) ~[placeholder-api-2.7.0+1.21.6-23b132bdbfc53dbe.jar:?]
        at knot/eu.pb4.placeholders.api.node.TextNode.toText(TextNode.java:23) ~[placeholder-api-2.7.0+1.21.6-23b132bdbfc53dbe.jar:?]
        at knot/eu.pb4.placeholders.api.parsers.StaticPreParser.parse(StaticPreParser.java:23) ~[placeholder-api-2.7.0+1.21.6-23b132bdbfc53dbe.jar:?]
        at knot/eu.pb4.placeholders.api.parsers.StaticPreParser.parseNodes(StaticPreParser.java:18) ~[placeholder-api-2.7.0+1.21.6-23b132bdbfc53dbe.jar:?]
        at knot/eu.pb4.placeholders.impl.textparser.MergedParser.parseNodes(MergedParser.java:50) ~[placeholder-api-2.7.0+1.21.6-23b132bdbfc53dbe.jar:?]
        at knot/de.example.servermessages.WrappedLangText.from(WrappedLangText.java:14) ~[servermessages-1.0.0-1.21.2.jar:?]
        at knot/de.example.servermessages.Config.<clinit>(Config.java:40) ~[servermessages-1.0.0-1.21.2.jar:?]
        at knot/net.minecraft.class_5250.handler$beh000$servermessages$replaceCustomTranslations(class_5250.java:534) ~[server-intermediary.jar:?]
        at knot/net.minecraft.class_5250.method_43477(class_5250.java) ~[server-intermediary.jar:?]
        at knot/net.minecraft.class_2561.method_43471(class_2561.java:152) ~[server-intermediary.jar:?]
        at knot/net.minecraft.class_2156.<clinit>(class_2156.java:24) ~[server-intermediary.jar:?]
        at knot/net.minecraft.class_155.<clinit>(class_155.java:244) ~[server-intermediary.jar:?]
        at knot/net.minecraft.server.Main.main(Main.java:71) ~[server-intermediary.jar:?]
        at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:480) ~[fabric-loader-0.16.14.jar:?]
        ... 4 more
 ```